### PR TITLE
Update FontForge link

### DIFF
--- a/Download.html
+++ b/Download.html
@@ -52,7 +52,7 @@
   </p>
   <ul>
     <li>
-      <strong>Description:</strong> Fonts in source form (SFD) for <a href="http://dejavu-fonts.org/wiki/FontForge" title="FontForge">FontForge</a>
+      <strong>Description:</strong> Fonts in source form (SFD) for <a href="http://fontforge.github.io" title="FontForge">FontForge</a>
     </li>
     <li>
       <strong>Size:</strong> 12050109 byte


### PR DESCRIPTION
the wiki http://dejavu-fonts.org seems to not exist anymore. Updating the FontForge link to the github.io page

The Contact http://dejavu-fonts.org/wiki/Contact and mailing list http://dejavu-fonts.org/wiki/Dejavu-fonts_mailing_list links need to be updated, but I don't know where to